### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server for interacting with the Figma API, featuring memory-efficient chunking and pagination capabilities for handling large Figma files.
 
+<a href="https://glama.ai/mcp/servers/@ArchimedesCrypto/figma-mcp-chunked">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ArchimedesCrypto/figma-mcp-chunked/badge" alt="Figma Server with Chunking MCP server" />
+</a>
+
 ## Overview
 
 This MCP server provides a robust interface to the Figma API with built-in memory management features. It's designed to handle large Figma files efficiently by breaking down operations into manageable chunks and implementing pagination where necessary.
@@ -240,7 +244,7 @@ The server provides detailed error messages and suggestions:
 
 ```typescript
 // Memory limit error
-"Response size too large. Try using a smaller depth value or specifying a node_id."
+"Response size too large. Try using a smaller depth value or specifying a node_id.""
 
 // Invalid parameters
 "Missing required parameters: fileKey and accessToken"


### PR DESCRIPTION
This PR adds a badge for the [Figma MCP Server with Chunking](https://glama.ai/mcp/servers/@ArchimedesCrypto/figma-mcp-chunked) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ArchimedesCrypto/figma-mcp-chunked">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ArchimedesCrypto/figma-mcp-chunked/badge" alt="Figma Server with Chunking MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.